### PR TITLE
add descriptions for the data sources; improve integration of Senzing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,40 +2,69 @@
 
 ## Creating high-quality knowledge graphs using Kùzu and Senzing
 
-This repo contains the code for a joint workshop between Kùzu and
-Senzing at KGC 2025. The focus is to show how to create high-quality
-knowledge graphs from heterogeneous data sources using Kùzu, an
-embedded, open source _graph database_, and Senzing, an SDK for
-_entity resolution_.
+This repo contains the code for a joint workshop between Kùzu and Senzing at KGC 2025.
+The focus is to show how to create high-quality knowledge graphs from heterogeneous
+data sources using Kùzu -- which is an embedded, open source _graph database_ -- and
+Senzing -- which is an SDK for _entity resolution_.
+
 
 ## Background
 
-The workshop will demonstrate an investigative graph analysis based on
-patterns of bad-actor tradecraft. Portions of the following input data
-sources will get used:
+The workshop will demonstrate an _investigative graph_ analysis based on patterns of
+bad-actor tradecraft. By connecting "risk" data and "link" data within a graph, we
+can show patterns of tradecraft such as money laundering, tax evasion, money mules,
+and so on. We'll use "slices" of datasets from the following open data providers:
 
   - <https://www.opensanctions.org/>
   - <https://www.openownership.org/>
 
+[OpenSanctions](https://www.opensanctions.org/) provides the "risk" category of data.
+In other words, this describes people and organizations who are known risks for FinCrime.
+There is also the [`yente`](https://github.com/opensanctions/yente) API which provides
+HTTP endpoints based on the [_FollowTheMoney_](https://followthemoney.tech/) data model
+used for investigations and OSInt.
+
+[Open Ownership](https://www.openownership.org/) provides the "link" category of data.
+This describes [_ultimate beneficial ownership_](https://en.wikipedia.org/wiki/Beneficial_ownership)
+(UBO) details: "Who owns how much of what, and who actually has controlling interest?"
+There's also the [_Beneficial Ownership Data Standard_](https://standard.openownership.org/en/0.4.0/)
+(BODS) which is an open standard providing guidance for collecting, sharing, and using
+high-quality beneficial ownership data, to support corporate ownership transparency.
+
+Recently, Open Ownership has partnered with [GLEIF](https://www.gleif.org/) to launch
+the [_Global Open Data Integration Network_](https://godin.gleif.org) (GODIN)
+to promote open standards across the world for data interoperability among these
+kinds of datasets related to investigating transnational corruption.
+
+There is also a repository with these datasets which are already formatted for
+use in Senzing <https://www.opensanctions.org/docs/bulk/senzing/> although these
+full sources are quite large to download.
+
+For the purposes of our tutorial, we've selected "slices" of data which connect to
+produce interesting subgraphs that illustrate patterns of bad-actor tradecraft.
+
+
 ## Tools
 
-We will be using Kùzu as the graph database and Senzing as the entity resolution engine.
-Docker is required to run the Senzing engine and to run Kùzu Explorer (a web-based UI for Kùzu).
-
-Visit the websites to see the installation instructions for each tool.
+We will be using Kùzu as the _graph database_ and Senzing as the _entity resolution_ engine.
+Docker is used to run both the Senzing SDK and Kùzu Explorer, a web-based UI for Kùzu.
+Visit the websites to see further instructions for each tool:
 
  - [Docker](https://docs.docker.com/desktop/)
  - [Kùzu](https://kuzudb.com/)
+ - [Senzing](https://senzing.com/) 
 
-For [Senzing](https://senzing.com/) we'll simply run within a Docker container.
+**Important:** You will need to have Docker downloaded and installed on your laptop to run this tutorial.
+Then we will run the Senzing SDK within a Docker container and load Kùzu as a Python package.
+
 
 ## Setup
 
 Set up a local Python environment in order to run the workshop steps.
 
-### Option 1: uv (recommended)
+### Option 1: `uv` (recommended)
 
-Use [these instructions](https://docs.astral.sh/uv/getting-started/installation/) to install uv for your OS.
+Use [these instructions](https://docs.astral.sh/uv/getting-started/installation/) to install `uv` for your OS.
 
 Next clone the GitHub repo to your laptop:
 
@@ -44,27 +73,33 @@ git clone https://github.com/kuzudb/kgc-2025-workshop-high-quality-graphs.git
 cd kgc-2025-workshop-high-quality-graphs
 ```
 
-Then use uv to install the Python library dependencies:
+Then use `uv` to install the Python library dependencies:
 
 ```bash
 uv sync
-# OR, install via requirements.txt
+```
+
+Or use `uv` to install based on the `requirements.txt` file:
+
+```bash
 uv pip install -r requirements.txt
 ```
 
-### Option 2: pip
+### Option 2: `pip` (fallback)
 
-If you don't want to use uv, you can use `pip` to install the dependencies via the
-`requirements.txt` file:
+If you don't want to use `uv`, you can use `pip` to install the dependencies through
+the `requirements.txt` file:
 
 ```bash
 pip install -r requirements.txt
 ```
 
+
 ## Data download
 
 Follow the instructions in the [data/README.md](data/README.md) file
 to download the required data.
+
 
 ## Running the Senzing container
 
@@ -81,14 +116,16 @@ from the <https://github.com/senzing-garage/> public repo on
 GitHub. These are located in the `/opt/senzing/g2/python` directory
 within the container.
 
-First among these, we'll run the Senzing configuration tool:
+First among these, we'll run the Senzing configuration tool to create
+a namespace for the data sources which we'll load later:
 
 ```bash
 G2ConfigTool.py
 ```
 
-When you get a `(g2cfg)` prompt, register the two data sources which
-you downloaded above:
+When you get a `(g2cfg)` prompt, register the two data sources which you downloaded above.
+In other words, each dataset has a column with an identifier -- either `"OPEN-SANCTIONS"`
+or `"OPEN-OWNERSHIP"` -- naming its source:
 
 ```
 addDataSource OPEN-SANCTIONS
@@ -107,8 +144,8 @@ G2Loader.py -f /tmp/data/open-sanctions.json
 G2Loader.py -f /tmp/data/open-ownership.json
 ```
 
-Senzing runs _entity resolution_ as the records get loaded, and then
-we can export results as a JSON file:
+Senzing runs _entity resolution_ as records are loaded.
+Then we can export the _entity resolution_ results as a JSON file:
 
 ```bash
 G2Export.py -F JSON -o /tmp/data/export.json
@@ -120,6 +157,7 @@ Finally, exit the container to return to your laptop environment:
 exit
 ```
 
+
 ## Running the workflow
 
 The workshop steps are implemented in the `create_graph.ipynb` notebook. A Python script version is
@@ -130,7 +168,7 @@ preprocessing steps required to create the graph:
 
  - `open_sanctions.py`: Handles the processing of the Open Sanctions data.
  - `open_ownership.py`: Handles the processing of the Open Ownership data.
- - `process_senzing.py`: Handles the processing of the entity-resolved data from Senzing.
+ - `process_senzing.py`: Handles the processing of the entity resolution export from Senzing.
 
 The steps to run the preprocessing, graph creation, and exploration
 steps are in the following files:
@@ -138,24 +176,24 @@ steps are in the following files:
  - `create_graph.ipynb`: Runs the preprocessing steps, creates the graph, and performs some basic exploration and visualization.
  - `create_graph.py`: Contains the same functionality as the notebook above, though as a Python script.
 
-To launch the `create_graph.ipynb` notebook in Jupyter Lab, run the following commands from the root directory of this repo:
+To launch the `create_graph.ipynb` notebook in JupyterLab, run the following commands from the root directory of this repo:
 
 ```bash
 source .venv/bin/activate
-jupyter lab
+.venv/bin/jupyter-lab
 ```
 
 Further visual exploration of the graph can be done using the Kùzu Explorer UI, whose steps are described below.
 
 ## Graph visualization in Kùzu Explorer
 
-To visualize the graph in Kùzu using its browser-based UI, Kùzu
-Explorer, run the following commands from this
+To visualize the graph in Kùzu using its browser-based UI, Kùzu Explorer, run the following commands from this
 root directory where the `docker-compose.yml` file is:
 
 ```bash
 docker compose up
 ```
+
 Alternatively, you can type in the following command in your terminal:
 
 ```bash
@@ -165,14 +203,11 @@ docker run -p 8000:8000 \
            --rm kuzudb/explorer:latest
 ```
 
-This will download and run the Kùzu Explorer image, and you can access
-the UI at <http://localhost:8000>
+This will download and run the Kùzu Explorer image, and you can access the UI at <http://localhost:8000>
 
-Make sure that the path to the database directory is set to the name
-of the Kùzu database directory in the code!
+Make sure that the path to the database directory is set to the name of the Kùzu database directory in the code!
 
-In the Explorer UI, enter the following Cypher query in the shell
-editor to visualize the graph:
+In the Explorer UI, enter the following Cypher query in the shell editor to visualize the graph:
 
 ```cypher
 MATCH (a:Entity)-[b*1..3]->(c)

--- a/create_graph.ipynb
+++ b/create_graph.ipynb
@@ -3,9 +3,18 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.318213Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.318020Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.426171Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.425819Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.318194Z"
+    }
+   },
    "outputs": [],
    "source": [
+    "import pathlib\n",
     "import shutil\n",
     "\n",
     "import kuzu\n",
@@ -15,6 +24,7 @@
     "import open_sanctions as os\n",
     "import open_ownership as oo\n",
     "import process_senzing as sz\n",
+    "\n",
     "# For visualizing the Kuzu graph in yFiles widget\n",
     "from yfiles_jupyter_graphs_for_kuzu import KuzuGraphWidget"
    ]
@@ -22,28 +32,36 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.426603Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.426513Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.436191Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.435843Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.426591Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Last updated: 2025-04-17T13:39:44.461133-04:00\n",
+      "Last updated: 2025-04-20T13:57:12.427373-07:00\n",
       "\n",
       "Python implementation: CPython\n",
       "Python version       : 3.13.2\n",
       "IPython version      : 9.1.0\n",
       "\n",
-      "Compiler    : Clang 20.1.0 \n",
+      "Compiler    : Clang 16.0.0 (clang-1600.0.26.6)\n",
       "OS          : Darwin\n",
       "Release     : 24.3.0\n",
       "Machine     : arm64\n",
       "Processor   : arm\n",
-      "CPU cores   : 12\n",
+      "CPU cores   : 14\n",
       "Architecture: 64bit\n",
       "\n",
-      "watermark                     : 2.5.0\n",
       "kuzu                          : 0.9.0\n",
+      "watermark                     : 2.5.0\n",
       "polars                        : 1.27.1\n",
       "yfiles_jupyter_graphs_for_kuzu: 0.0.3\n",
       "\n"
@@ -59,11 +77,20 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.436852Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.436717Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.456225Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.455977Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.436834Z"
+    }
+   },
    "outputs": [],
    "source": [
     "DB_PATH = \"./db\"\n",
     "shutil.rmtree(DB_PATH, ignore_errors=True)\n",
+    "\n",
     "db = kuzu.Database(DB_PATH)\n",
     "conn = kuzu.Connection(db)"
    ]
@@ -78,16 +105,40 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.456740Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.456640Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.458485Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.458234Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.456732Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "df1 = pl.read_ndjson(\"data/open-sanctions.json\")"
+    "data_path: pathlib.Path = pathlib.Path(\"data\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll load a slice of the [OpenSanctions](https://www.opensanctions.org/) dataset, which provides the \"risk\" category of data.\n",
+    "This describes people and organizations who represent known risks for FinCrime."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.458933Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.458811Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.464935Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.464667Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.458924Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -99,7 +150,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (3, 15)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>DATA_SOURCE</th><th>RECORD_ID</th><th>RECORD_TYPE</th><th>LAST_CHANGE</th><th>NAMES</th><th>GENDER</th><th>RISKS</th><th>ADDRESSES</th><th>DATES</th><th>COUNTRIES</th><th>IDENTIFIERS</th><th>SOURCE_LINKS</th><th>RELATIONSHIPS</th><th>URL</th><th>CONTACTS</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>list[struct[3]]</td><td>str</td><td>list[struct[1]]</td><td>list[struct[7]]</td><td>list[struct[2]]</td><td>list[struct[3]]</td><td>list[struct[9]]</td><td>list[struct[1]]</td><td>list[struct[5]]</td><td>str</td><td>list[struct[1]]</td></tr></thead><tbody><tr><td>&quot;OPEN_SANCTIONS&quot;</td><td>&quot;NK-25vyVFzt8vdJGgAXMRTwTJ&quot;</td><td>&quot;PERSON&quot;</td><td>&quot;2024-07-30T16:41:14&quot;</td><td>[{&quot;PRIMARY&quot;,null,&quot;Abassin BADSHAH&quot;}]</td><td>null</td><td>[{&quot;corp.disqual&quot;}]</td><td>[{&quot;31 Quernmore Close, Bromley, Kent, United Kingdom, BR1 4EL&quot;,null,null,null,null,null,null}]</td><td>[{null,&quot;1985-05-12&quot;}]</td><td>[{null,&quot;gb&quot;,null}]</td><td>[{null,null,null,null,null,&quot;OPEN_SANCTIONS&quot;,&quot;NK-25vyVFzt8vdJGgAXMRTwTJ&quot;,null,null}]</td><td>[{&quot;https://find-and-update.company-information.service.gov.uk/disqualified-officers/natural/mGquuTbmESWiRmHJPz1ObUwfDgk&quot;}]</td><td>[{null,null,&quot;Directorship&quot;,&quot;OPEN_SANCTIONS&quot;,&quot;NK-SKAADAiqiZ78JsJjeg72Te&quot;}, {null,null,&quot;Directorship&quot;,&quot;OPEN_SANCTIONS&quot;,&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;}]</td><td>&quot;https://www.opensanctions.org/…</td><td>null</td></tr><tr><td>&quot;OPEN_SANCTIONS&quot;</td><td>&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;</td><td>&quot;ORGANIZATION&quot;</td><td>&quot;2025-01-07T00:33:03&quot;</td><td>[{&quot;PRIMARY&quot;,&quot;LMAR (GB) LTD&quot;,null}]</td><td>null</td><td>null</td><td>[{&quot;31 Quernmore Close, Bromley, Kent, United Kingdom, BR1 4EL&quot;,null,null,null,null,null,&quot;BUSINESS&quot;}]</td><td>null</td><td>[{&quot;gb&quot;,null,null}]</td><td>[{null,null,null,null,null,&quot;OPEN_SANCTIONS&quot;,&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;,null,null}]</td><td>null</td><td>[{&quot;OPEN_SANCTIONS&quot;,&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;,null,null,null}]</td><td>&quot;https://www.opensanctions.org/…</td><td>null</td></tr><tr><td>&quot;OPEN-SANCTIONS&quot;</td><td>&quot;NK-auyPsLrBzRoxjCRWgjBvas&quot;</td><td>&quot;ORGANIZATION&quot;</td><td>&quot;2024-03-03T19:51:29&quot;</td><td>[{&quot;PRIMARY&quot;,&quot;WANDLE HOLDINGS LIMITED&quot;,null}]</td><td>null</td><td>[{&quot;sanction.linked&quot;}]</td><td>[{&quot;DEANA BEACH APTS, BLOCK A, Flat 212, Προμαχών Ελευθερίας, 33, &#x27;Αγιος Αθανάσιος, 4103, Λεμεσός, Κύπρος&quot;,null,null,null,null,null,&quot;BUSINESS&quot;}]</td><td>[{&quot;2006-12-08&quot;,null}]</td><td>[{&quot;cy&quot;,null,null}]</td><td>[{null,&quot;C188266&quot;,null,null,null,null,null,null,null}, {null,&quot;HE188266&quot;,null,null,null,null,null,null,null}, {null,null,null,null,null,&quot;OPEN-SANCTIONS&quot;,&quot;NK-auyPsLrBzRoxjCRWgjBvas&quot;,null,null}]</td><td>null</td><td>[{&quot;OPEN-SANCTIONS&quot;,&quot;NK-auyPsLrBzRoxjCRWgjBvas&quot;,null,null,null}]</td><td>&quot;https://opensanctions.org/enti…</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (3, 15)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>DATA_SOURCE</th><th>RECORD_ID</th><th>RECORD_TYPE</th><th>LAST_CHANGE</th><th>NAMES</th><th>GENDER</th><th>RISKS</th><th>ADDRESSES</th><th>DATES</th><th>COUNTRIES</th><th>IDENTIFIERS</th><th>SOURCE_LINKS</th><th>RELATIONSHIPS</th><th>URL</th><th>CONTACTS</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>list[struct[3]]</td><td>str</td><td>list[struct[1]]</td><td>list[struct[7]]</td><td>list[struct[2]]</td><td>list[struct[3]]</td><td>list[struct[9]]</td><td>list[struct[1]]</td><td>list[struct[5]]</td><td>str</td><td>list[struct[1]]</td></tr></thead><tbody><tr><td>&quot;OPEN-SANCTIONS&quot;</td><td>&quot;NK-25vyVFzt8vdJGgAXMRTwTJ&quot;</td><td>&quot;PERSON&quot;</td><td>&quot;2024-07-30T16:41:14&quot;</td><td>[{&quot;PRIMARY&quot;,null,&quot;Abassin BADSHAH&quot;}]</td><td>null</td><td>[{&quot;corp.disqual&quot;}]</td><td>[{&quot;31 Quernmore Close, Bromley, Kent, United Kingdom, BR1 4EL&quot;,null,null,null,null,null,null}]</td><td>[{null,&quot;1985-05-12&quot;}]</td><td>[{null,&quot;gb&quot;,null}]</td><td>[{null,null,null,null,&quot;OPEN-SANCTIONS&quot;,&quot;NK-25vyVFzt8vdJGgAXMRTwTJ&quot;,null,null,null}]</td><td>[{&quot;https://find-and-update.company-information.service.gov.uk/disqualified-officers/natural/mGquuTbmESWiRmHJPz1ObUwfDgk&quot;}]</td><td>[{&quot;Directorship&quot;,&quot;OPEN-SANCTIONS&quot;,&quot;NK-SKAADAiqiZ78JsJjeg72Te&quot;,null,null}, {&quot;Directorship&quot;,&quot;OPEN-SANCTIONS&quot;,&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;,null,null}]</td><td>&quot;https://www.opensanctions.org/…</td><td>null</td></tr><tr><td>&quot;OPEN-SANCTIONS&quot;</td><td>&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;</td><td>&quot;ORGANIZATION&quot;</td><td>&quot;2025-01-07T00:33:03&quot;</td><td>[{&quot;PRIMARY&quot;,&quot;LMAR (GB) LTD&quot;,null}]</td><td>null</td><td>null</td><td>[{&quot;31 Quernmore Close, Bromley, Kent, United Kingdom, BR1 4EL&quot;,null,null,null,null,null,&quot;BUSINESS&quot;}]</td><td>null</td><td>[{&quot;gb&quot;,null,null}]</td><td>[{null,null,null,null,&quot;OPEN-SANCTIONS&quot;,&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;,null,null,null}]</td><td>null</td><td>[{null,null,null,&quot;OPEN-SANCTIONS&quot;,&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;}]</td><td>&quot;https://www.opensanctions.org/…</td><td>null</td></tr><tr><td>&quot;OPEN-SANCTIONS&quot;</td><td>&quot;NK-auyPsLrBzRoxjCRWgjBvas&quot;</td><td>&quot;ORGANIZATION&quot;</td><td>&quot;2024-03-03T19:51:29&quot;</td><td>[{&quot;PRIMARY&quot;,&quot;WANDLE HOLDINGS LIMITED&quot;,null}]</td><td>null</td><td>[{&quot;sanction.linked&quot;}]</td><td>[{&quot;DEANA BEACH APTS, BLOCK A, Flat 212, Προμαχών Ελευθερίας, 33, &#x27;Αγιος Αθανάσιος, 4103, Λεμεσός, Κύπρος&quot;,null,null,null,null,null,&quot;BUSINESS&quot;}]</td><td>[{&quot;2006-12-08&quot;,null}]</td><td>[{&quot;cy&quot;,null,null}]</td><td>[{&quot;C188266&quot;,null,null,null,null,null,null,null,null}, {&quot;HE188266&quot;,null,null,null,null,null,null,null,null}, {null,null,null,null,&quot;OPEN-SANCTIONS&quot;,&quot;NK-auyPsLrBzRoxjCRWgjBvas&quot;,null,null,null}]</td><td>null</td><td>[{null,null,null,&quot;OPEN-SANCTIONS&quot;,&quot;NK-auyPsLrBzRoxjCRWgjBvas&quot;}]</td><td>&quot;https://opensanctions.org/enti…</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (3, 15)\n",
@@ -110,18 +161,18 @@
        "│ str       ┆           ┆ str       ┆ str       ┆   ┆ list[stru ┆ list[stru ┆           ┆ uct[1]]  │\n",
        "│           ┆           ┆           ┆           ┆   ┆ ct[1]]    ┆ ct[5]]    ┆           ┆          │\n",
        "╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡\n",
-       "│ OPEN_SANC ┆ NK-25vyVF ┆ PERSON    ┆ 2024-07-3 ┆ … ┆ [{\"https: ┆ [{null,nu ┆ https://w ┆ null     │\n",
-       "│ TIONS     ┆ zt8vdJGgA ┆           ┆ 0T16:41:1 ┆   ┆ //find-an ┆ ll,\"Direc ┆ ww.opensa ┆          │\n",
-       "│           ┆ XMRTwTJ   ┆           ┆ 4         ┆   ┆ d-update. ┆ torship\", ┆ nctions.o ┆          │\n",
-       "│           ┆           ┆           ┆           ┆   ┆ com…      ┆ \"OP…      ┆ rg/…      ┆          │\n",
-       "│ OPEN_SANC ┆ NK-3p3mmV ┆ ORGANIZAT ┆ 2025-01-0 ┆ … ┆ null      ┆ [{\"OPEN_S ┆ https://w ┆ null     │\n",
-       "│ TIONS     ┆ WmjwVtTfK ┆ ION       ┆ 7T00:33:0 ┆   ┆           ┆ ANCTIONS\" ┆ ww.opensa ┆          │\n",
-       "│           ┆ chz4kNE   ┆           ┆ 3         ┆   ┆           ┆ ,\"NK-3p3m ┆ nctions.o ┆          │\n",
-       "│           ┆           ┆           ┆           ┆   ┆           ┆ mVW…      ┆ rg/…      ┆          │\n",
-       "│ OPEN-SANC ┆ NK-auyPsL ┆ ORGANIZAT ┆ 2024-03-0 ┆ … ┆ null      ┆ [{\"OPEN-S ┆ https://o ┆ null     │\n",
-       "│ TIONS     ┆ rBzRoxjCR ┆ ION       ┆ 3T19:51:2 ┆   ┆           ┆ ANCTIONS\" ┆ pensancti ┆          │\n",
-       "│           ┆ WgjBvas   ┆           ┆ 9         ┆   ┆           ┆ ,\"NK-auyP ┆ ons.org/e ┆          │\n",
-       "│           ┆           ┆           ┆           ┆   ┆           ┆ sLr…      ┆ nti…      ┆          │\n",
+       "│ OPEN-SANC ┆ NK-25vyVF ┆ PERSON    ┆ 2024-07-3 ┆ … ┆ [{\"https: ┆ [{\"Direct ┆ https://w ┆ null     │\n",
+       "│ TIONS     ┆ zt8vdJGgA ┆           ┆ 0T16:41:1 ┆   ┆ //find-an ┆ orship\",\" ┆ ww.opensa ┆          │\n",
+       "│           ┆ XMRTwTJ   ┆           ┆ 4         ┆   ┆ d-update. ┆ OPEN-SANC ┆ nctions.o ┆          │\n",
+       "│           ┆           ┆           ┆           ┆   ┆ com…      ┆ TIO…      ┆ rg/…      ┆          │\n",
+       "│ OPEN-SANC ┆ NK-3p3mmV ┆ ORGANIZAT ┆ 2025-01-0 ┆ … ┆ null      ┆ [{null,nu ┆ https://w ┆ null     │\n",
+       "│ TIONS     ┆ WmjwVtTfK ┆ ION       ┆ 7T00:33:0 ┆   ┆           ┆ ll,null,\" ┆ ww.opensa ┆          │\n",
+       "│           ┆ chz4kNE   ┆           ┆ 3         ┆   ┆           ┆ OPEN-SANC ┆ nctions.o ┆          │\n",
+       "│           ┆           ┆           ┆           ┆   ┆           ┆ TIO…      ┆ rg/…      ┆          │\n",
+       "│ OPEN-SANC ┆ NK-auyPsL ┆ ORGANIZAT ┆ 2024-03-0 ┆ … ┆ null      ┆ [{null,nu ┆ https://o ┆ null     │\n",
+       "│ TIONS     ┆ rBzRoxjCR ┆ ION       ┆ 3T19:51:2 ┆   ┆           ┆ ll,null,\" ┆ pensancti ┆          │\n",
+       "│           ┆ WgjBvas   ┆           ┆ 9         ┆   ┆           ┆ OPEN-SANC ┆ ons.org/e ┆          │\n",
+       "│           ┆           ┆           ┆           ┆   ┆           ┆ TIO…      ┆ nti…      ┆          │\n",
        "└───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘"
       ]
      },
@@ -131,6 +182,7 @@
     }
    ],
    "source": [
+    "df1 = pl.read_ndjson(data_path / \"open-sanctions.json\")\n",
     "df1.head(3)"
    ]
   },
@@ -138,13 +190,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each entity ID from Open Sanctions has a risk classification. This can be useful to associate an ID with a particular risk, allowing us to narrow down on candidates that are relevant to a particular investigation."
+    "Each entity ID from OpenSanctions has a risk classification. This can be useful to associate an ID with a particular risk, allowing us to narrow down on candidates that are relevant to a particular investigation."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.466658Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.466507Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.470078Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.469844Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.466634Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -192,7 +252,15 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.470569Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.470486Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.475045Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.474774Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.470562Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -237,22 +305,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Of particular interest for this workshop is the person \"Abassin Badshah\", owner of multiple Papa John's franchises in London, who is known for his tax evasion conviction in 2021."
+    "Of particular interest for this workshop is the person [\"Abassin Badshah\"](https://find-and-update.company-information.service.gov.uk/disqualified-officers/natural/mGquuTbmESWiRmHJPz1ObUwfDgk), former owner of multiple Papa John's franchises in London, who is disqualified from being a corporate director until 2026, due to his [tax evasion conviction](https://londonnewsonline.co.uk/news/catford-papa-johns-pizza-boss-jailed-after-669000-tax-evasion/) in 2021."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Open Ownership\n",
-    "\n",
-    "Open Ownership describes _ultimate beneficial ownership_ (UBO) details, which provides the \"link\" category of data.\n"
+    "## Open Ownership"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Open Ownership](https://www.openownership.org/) describes _ultimate beneficial ownership_ (UBO) details, which provides the \"link\" category of data. In other words, \"Who owns how much of what, and who actually has controlling interest?\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.475761Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.475514Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.485894Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.485659Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.475752Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -293,7 +374,7 @@
     }
    ],
    "source": [
-    "df2 = pl.read_ndjson(\"data/open-ownership.json\")\n",
+    "df2 = pl.read_ndjson(data_path / \"open-ownership.json\")\n",
     "df2.head(3)"
    ]
   },
@@ -301,13 +382,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Just like the Open Sanctions data, we can use the `extract_open_ownership` function to process the nested JSON data and return the relevant columns that we need for our graph."
+    "Just like with the OpenSanctions data, we can use the `extract_open_ownership` function to process the nested JSON data and return the relevant columns that we need for our graph."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.486383Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.486287Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.491675Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.491431Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.486376Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -351,13 +440,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the relationships in our graph, we'll need to select only the relationships that have **both** `src` and `dst` in the list of ids. This is done via the `extract_open_ownership_relationships` function."
+    "For the relationships in our graph, we'll need to select only the relationships that have **both** `src_id` and `dst_id` in the list of ids. This is done via the `extract_open_ownership_relationships` function."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.492259Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.492134Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.496679Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.496406Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.492248Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -399,62 +496,54 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Senzing workflow\n",
-    "\n",
-    "To generate high quality entity data, we'll use Senzing to process the Open Sanctions and Open Ownership data via the Senzing Python SDK. The returned data from Senzing contains resolved entities (in `export.json`), which is once again nested JSON that we can use to create our graph."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (3, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>RESOLVED_ENTITY</th><th>RELATED_ENTITIES</th></tr><tr><td>struct[2]</td><td>list[struct[8]]</td></tr></thead><tbody><tr><td>{1,[{&quot;OPEN-SANCTIONS&quot;,&quot;NK-25vyVFzt8vdJGgAXMRTwTJ&quot;,&quot;GENERIC&quot;,1,&quot;49B1F5D5BB70A51ECD1E5DED69A3F99F46232F8D&quot;,&quot;Abassin BADSHAH&quot;,&quot;&quot;,0,&quot;&quot;,&quot;&quot;,&quot;2025-02-02 22:33:52.027&quot;}, {&quot;OPEN-OWNERSHIP&quot;,&quot;17207853441353212969&quot;,&quot;GENERIC&quot;,100121,&quot;4237F29B220116BE634753371BE3529B08F97201&quot;,&quot;Abassin Badshah&quot;,&quot;+NAME+ADDRESS+NATIONALITY&quot;,1,&quot;RESOLVED&quot;,&quot;CNAME_CFF&quot;,&quot;2025-02-02 22:34:26.260&quot;}, {&quot;OPEN-OWNERSHIP&quot;,&quot;6747548100436839873&quot;,&quot;GENERIC&quot;,100211,&quot;793D2A980A44DD047ECD8603B2CC8E2045F59858&quot;,&quot;Abassin Badshah&quot;,&quot;+NAME+DOB+NATIONALITY&quot;,1,&quot;RESOLVED&quot;,&quot;SNAME_SSTAB&quot;,&quot;2025-02-02 22:34:26.994&quot;}]}</td><td>[{2,11,&quot;DISCLOSED&quot;,&quot;+OPEN-SANCTIONS(DIRECTORSHIP:)&quot;,&quot;DISCLOSED&quot;,1,0,[{&quot;OPEN-SANCTIONS&quot;,&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;}]}, {9,11,&quot;DISCLOSED&quot;,&quot;+ADDRESS+OOR(:SHAREHOLDING 50% 75%,VOTING_RIGHTS 50% 75%)+OPEN-SANCTIONS(DIRECTORSHIP:)-RECORD_TYPE&quot;,&quot;DISCLOSED&quot;,3,0,[{&quot;OPEN-SANCTIONS&quot;,&quot;NK-SKAADAiqiZ78JsJjeg72Te&quot;}, {&quot;OPEN-OWNERSHIP&quot;,&quot;17892212632775799925&quot;}]}, … {100132,3,&quot;POSSIBLY_RELATED&quot;,&quot;+ADDRESS+NATIONALITY&quot;,&quot;CFF&quot;,0,0,[{&quot;OPEN-OWNERSHIP&quot;,&quot;17952626459015773513&quot;}]}]</td></tr><tr><td>{2,[{&quot;OPEN-SANCTIONS&quot;,&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;,&quot;GENERIC&quot;,2,&quot;5D0549B7E9CB8BBE38DF3B595650C56C4A35BB7C&quot;,&quot;LMAR (GB) LTD&quot;,&quot;&quot;,0,&quot;&quot;,&quot;&quot;,&quot;2025-02-02 22:33:52.034&quot;}]}</td><td>[{1,11,&quot;DISCLOSED&quot;,&quot;+OPEN-SANCTIONS(:DIRECTORSHIP)&quot;,&quot;DISCLOSED&quot;,1,0,[{&quot;OPEN-SANCTIONS&quot;,&quot;NK-25vyVFzt8vdJGgAXMRTwTJ&quot;}, {&quot;OPEN-OWNERSHIP&quot;,&quot;17207853441353212969&quot;}, {&quot;OPEN-OWNERSHIP&quot;,&quot;6747548100436839873&quot;}]}]</td></tr><tr><td>{3,[{&quot;OPEN-SANCTIONS&quot;,&quot;NK-auyPsLrBzRoxjCRWgjBvas&quot;,&quot;GENERIC&quot;,3,&quot;CE753D92E4AE9DA3A712F4846CF374D6243098E2&quot;,&quot;WANDLE HOLDINGS LIMITED&quot;,&quot;&quot;,0,&quot;&quot;,&quot;&quot;,&quot;2025-02-02 22:33:52.037&quot;}]}</td><td>[{12,11,&quot;DISCLOSED&quot;,&quot;+OPEN-SANCTIONS(:BENEFICIARY)&quot;,&quot;DISCLOSED&quot;,1,0,[{&quot;OPEN-SANCTIONS&quot;,&quot;Q44155839&quot;}]}]</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (3, 2)\n",
-       "┌─────────────────────────────────┬─────────────────────────────────┐\n",
-       "│ RESOLVED_ENTITY                 ┆ RELATED_ENTITIES                │\n",
-       "│ ---                             ┆ ---                             │\n",
-       "│ struct[2]                       ┆ list[struct[8]]                 │\n",
-       "╞═════════════════════════════════╪═════════════════════════════════╡\n",
-       "│ {1,[{\"OPEN-SANCTIONS\",\"NK-25vy… ┆ [{2,11,\"DISCLOSED\",\"+OPEN-SANC… │\n",
-       "│ {2,[{\"OPEN-SANCTIONS\",\"NK-3p3m… ┆ [{1,11,\"DISCLOSED\",\"+OPEN-SANC… │\n",
-       "│ {3,[{\"OPEN-SANCTIONS\",\"NK-auyP… ┆ [{12,11,\"DISCLOSED\",\"+OPEN-SAN… │\n",
-       "└─────────────────────────────────┴─────────────────────────────────┘"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df3 = pl.read_ndjson(\"data/export.json\")\n",
-    "df3.head(3)"
+    "## Senzing workflow"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Due to the deeply nested nature of the data, we'll have to process the data in a few steps using the `process_senzing_export` function. Each entity is assigned a unique identifier with the prefix `sz_`, associated with the record ID from the original data, and which data source it comes from."
+    "To generate high quality entity data, we'll use Senzing to process the OpenSanctions and Open Ownership data via the Senzing Python SDK. The returned data from Senzing contains resolved entities (in `export.json`), which is once again nested JSON that we can use to create our graph.\n",
+    "\n",
+    "Due to the deeply nested nature of this data, we'll have to process it in a few steps using the `process_senzing_export()` function. Each entity is assigned a unique identifier with the prefix `sz_`, associated with the record ID from the original data, plus its data source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.497239Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.497115Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.502133Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.501877Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.497230Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sz_export = sz.process_senzing_export(data_path / \"export.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This first dataframe `df_ent` lists the entities identified by Senzing _entity resolution_."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.502587Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.502508Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.505167Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.504926Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.502581Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -466,22 +555,19 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (3, 6)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>ent_id</th><th>rec_id</th><th>source</th><th>descrip</th><th>level</th><th>why</th></tr><tr><td>str</td><td>str</td><td>str</td><td>str</td><td>i8</td><td>str</td></tr></thead><tbody><tr><td>&quot;sz_1&quot;</td><td>&quot;NK-25vyVFzt8vdJGgAXMRTwTJ&quot;</td><td>&quot;OPEN-SANCTIONS&quot;</td><td>&quot;Abassin BADSHAH&quot;</td><td>0</td><td>null</td></tr><tr><td>&quot;sz_1&quot;</td><td>&quot;17207853441353212969&quot;</td><td>&quot;OPEN-OWNERSHIP&quot;</td><td>&quot;Abassin Badshah&quot;</td><td>1</td><td>&quot;+NAME+ADDRESS+NATIONALITY&quot;</td></tr><tr><td>&quot;sz_1&quot;</td><td>&quot;6747548100436839873&quot;</td><td>&quot;OPEN-OWNERSHIP&quot;</td><td>&quot;Abassin Badshah&quot;</td><td>1</td><td>&quot;+NAME+DOB+NATIONALITY&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (3, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>id</th><th>descrip</th></tr><tr><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;sz_1&quot;</td><td>&quot;Abassin Badshah&quot;</td></tr><tr><td>&quot;sz_10&quot;</td><td>&quot;Nicholas Thomas Wright&quot;</td></tr><tr><td>&quot;sz_100001&quot;</td><td>&quot;Gold Wynn Uk Holdings Limited&quot;</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (3, 6)\n",
-       "┌────────┬───────────────────────┬────────────────┬─────────────────┬───────┬──────────────────────┐\n",
-       "│ ent_id ┆ rec_id                ┆ source         ┆ descrip         ┆ level ┆ why                  │\n",
-       "│ ---    ┆ ---                   ┆ ---            ┆ ---             ┆ ---   ┆ ---                  │\n",
-       "│ str    ┆ str                   ┆ str            ┆ str             ┆ i8    ┆ str                  │\n",
-       "╞════════╪═══════════════════════╪════════════════╪═════════════════╪═══════╪══════════════════════╡\n",
-       "│ sz_1   ┆ NK-25vyVFzt8vdJGgAXMR ┆ OPEN-SANCTIONS ┆ Abassin BADSHAH ┆ 0     ┆ null                 │\n",
-       "│        ┆ TwTJ                  ┆                ┆                 ┆       ┆                      │\n",
-       "│ sz_1   ┆ 17207853441353212969  ┆ OPEN-OWNERSHIP ┆ Abassin Badshah ┆ 1     ┆ +NAME+ADDRESS+NATION │\n",
-       "│        ┆                       ┆                ┆                 ┆       ┆ ALITY                │\n",
-       "│ sz_1   ┆ 6747548100436839873   ┆ OPEN-OWNERSHIP ┆ Abassin Badshah ┆ 1     ┆ +NAME+DOB+NATIONALIT │\n",
-       "│        ┆                       ┆                ┆                 ┆       ┆ Y                    │\n",
-       "└────────┴───────────────────────┴────────────────┴─────────────────┴───────┴──────────────────────┘"
+       "shape: (3, 2)\n",
+       "┌───────────┬───────────────────────────────┐\n",
+       "│ id        ┆ descrip                       │\n",
+       "│ ---       ┆ ---                           │\n",
+       "│ str       ┆ str                           │\n",
+       "╞═══════════╪═══════════════════════════════╡\n",
+       "│ sz_1      ┆ Abassin Badshah               │\n",
+       "│ sz_10     ┆ Nicholas Thomas Wright        │\n",
+       "│ sz_100001 ┆ Gold Wynn Uk Holdings Limited │\n",
+       "└───────────┴───────────────────────────────┘"
       ]
      },
      "execution_count": 12,
@@ -490,21 +576,29 @@
     }
    ],
    "source": [
-    "df_sz = sz.process_senzing_export(df3)\n",
-    "df_sz.head(3)"
+    "df_ent = sz_export.df_ent.sort(\"id\")\n",
+    "df_ent.head(3)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll need to create `Matched` relationships between the entities in our graph. This is done via the `extract_related_entities` function. The from/to columns in the following table are the source and destination Senzing identifiers."
+    "The `df_rel` dataframe lists probabilistic relationships between entities, also identified by Senzing _entity resolution_. In other words, there isn't sufficient evidence _yet_ to merge these entities; however, there's enough evidence to suggest following these as closely related leads during an investigation."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.505571Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.505503Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.507780Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.507502Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.505564Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -516,17 +610,17 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (3, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>ent_id</th><th>rel_id</th><th>why</th><th>level</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i8</td></tr></thead><tbody><tr><td>&quot;sz_1&quot;</td><td>&quot;sz_2&quot;</td><td>&quot;+OPEN-SANCTIONS(DIRECTORSHIP:)&quot;</td><td>11</td></tr><tr><td>&quot;sz_1&quot;</td><td>&quot;sz_9&quot;</td><td>&quot;+ADDRESS+OOR(:SHAREHOLDING 50%…</td><td>11</td></tr><tr><td>&quot;sz_1&quot;</td><td>&quot;sz_100075&quot;</td><td>&quot;+ADDRESS+OOR(:APPOINTMENT_OF_B…</td><td>11</td></tr></tbody></table></div>"
+       "<small>shape: (3, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>ent_id</th><th>rel_id</th><th>why</th><th>level</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;sz_1&quot;</td><td>&quot;sz_2&quot;</td><td>&quot;+ADDRESS+OPEN-SANCTIONS(DIRECT…</td><td>11</td></tr><tr><td>&quot;sz_1&quot;</td><td>&quot;sz_9&quot;</td><td>&quot;+ADDRESS+OPEN-SANCTIONS(DIRECT…</td><td>11</td></tr><tr><td>&quot;sz_1&quot;</td><td>&quot;sz_100075&quot;</td><td>&quot;+ADDRESS+OOR(:APPOINTMENT_OF_B…</td><td>11</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (3, 4)\n",
        "┌────────┬───────────┬─────────────────────────────────┬───────┐\n",
        "│ ent_id ┆ rel_id    ┆ why                             ┆ level │\n",
        "│ ---    ┆ ---       ┆ ---                             ┆ ---   │\n",
-       "│ str    ┆ str       ┆ str                             ┆ i8    │\n",
+       "│ str    ┆ str       ┆ str                             ┆ i64   │\n",
        "╞════════╪═══════════╪═════════════════════════════════╪═══════╡\n",
-       "│ sz_1   ┆ sz_2      ┆ +OPEN-SANCTIONS(DIRECTORSHIP:)  ┆ 11    │\n",
-       "│ sz_1   ┆ sz_9      ┆ +ADDRESS+OOR(:SHAREHOLDING 50%… ┆ 11    │\n",
+       "│ sz_1   ┆ sz_2      ┆ +ADDRESS+OPEN-SANCTIONS(DIRECT… ┆ 11    │\n",
+       "│ sz_1   ┆ sz_9      ┆ +ADDRESS+OPEN-SANCTIONS(DIRECT… ┆ 11    │\n",
        "│ sz_1   ┆ sz_100075 ┆ +ADDRESS+OOR(:APPOINTMENT_OF_B… ┆ 11    │\n",
        "└────────┴───────────┴─────────────────────────────────┴───────┘"
       ]
@@ -537,21 +631,36 @@
     }
    ],
    "source": [
-    "df_rel = sz.extract_related_entities(df3)\n",
-    "df_rel.head(3)\n"
+    "df_rel = sz_export.df_rel\n",
+    "df_rel.head(3)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The entity DataFrame `df_sz` contains multiple records for each entity, so we need to ensure that we only include one record per entity."
+    "### Separate the Senzing entities by source"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The final step to preprocess the data for our graph is to separate the entities by their source (whether they come from Open Sanctions or Open Ownership)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.508324Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.508214Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.510759Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.510534Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.508316Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -563,19 +672,19 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (3, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>ent_id</th><th>descrip</th></tr><tr><td>str</td><td>str</td></tr></thead><tbody><tr><td>&quot;sz_1&quot;</td><td>&quot;Abassin BADSHAH&quot;</td></tr><tr><td>&quot;sz_10&quot;</td><td>&quot;ニコラス・トマス・ライト&quot;</td></tr><tr><td>&quot;sz_100001&quot;</td><td>&quot;GOLD WYNN UK HOLDINGS LIMITED&quot;</td></tr></tbody></table></div>"
+       "<small>shape: (3, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>ent_id</th><th>rec_id</th><th>why</th><th>level</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;sz_1&quot;</td><td>&quot;17207853441353212969&quot;</td><td>&quot;+NAME+ADDRESS+NATIONALITY&quot;</td><td>1</td></tr><tr><td>&quot;sz_1&quot;</td><td>&quot;6747548100436839873&quot;</td><td>&quot;+NAME+DOB+NATIONALITY&quot;</td><td>1</td></tr><tr><td>&quot;sz_10&quot;</td><td>&quot;5927522753545014068&quot;</td><td>&quot;+NAME+DOB+NATIONALITY&quot;</td><td>1</td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "shape: (3, 2)\n",
-       "┌───────────┬───────────────────────────────┐\n",
-       "│ ent_id    ┆ descrip                       │\n",
-       "│ ---       ┆ ---                           │\n",
-       "│ str       ┆ str                           │\n",
-       "╞═══════════╪═══════════════════════════════╡\n",
-       "│ sz_1      ┆ Abassin BADSHAH               │\n",
-       "│ sz_10     ┆ ニコラス・トマス・ライト      │\n",
-       "│ sz_100001 ┆ GOLD WYNN UK HOLDINGS LIMITED │\n",
-       "└───────────┴───────────────────────────────┘"
+       "shape: (3, 4)\n",
+       "┌────────┬──────────────────────┬───────────────────────────┬───────┐\n",
+       "│ ent_id ┆ rec_id               ┆ why                       ┆ level │\n",
+       "│ ---    ┆ ---                  ┆ ---                       ┆ ---   │\n",
+       "│ str    ┆ str                  ┆ str                       ┆ i64   │\n",
+       "╞════════╪══════════════════════╪═══════════════════════════╪═══════╡\n",
+       "│ sz_1   ┆ 17207853441353212969 ┆ +NAME+ADDRESS+NATIONALITY ┆ 1     │\n",
+       "│ sz_1   ┆ 6747548100436839873  ┆ +NAME+DOB+NATIONALITY     ┆ 1     │\n",
+       "│ sz_10  ┆ 5927522753545014068  ┆ +NAME+DOB+NATIONALITY     ┆ 1     │\n",
+       "└────────┴──────────────────────┴───────────────────────────┴───────┘"
       ]
      },
      "execution_count": 14,
@@ -584,41 +693,69 @@
     }
    ],
    "source": [
-    "df_ent = (\n",
-    "    # df_sz.filter(pl.col(\"why\").is_not_null())  # Throw away entities that don't have a \"why\"\n",
-    "    df_sz.unique(subset=[\"ent_id\"])\n",
-    "    .select(\"ent_id\", \"descrip\")\n",
-    "    .sort(\"ent_id\")\n",
-    ")\n",
-    "\n",
-    "df_ent.head(3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Separate Senzing entities by source\n",
-    "\n",
-    "The final step to preprocess the data for our graph is to separate the entities by their source (whether they are from Open Sanctions or Open Ownership)."
+    "df_sz_oo = sz_export.df_rec.filter(pl.col(\"source\") == \"OPEN-OWNERSHIP\").select(\"ent_id\", \"rec_id\", \"why\", \"level\")\n",
+    "df_sz_oo.head(3)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.511265Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.511179Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.513782Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.513439Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.511258Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 4)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>ent_id</th><th>rec_id</th><th>why</th><th>level</th></tr><tr><td>str</td><td>str</td><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;sz_1&quot;</td><td>&quot;NK-25vyVFzt8vdJGgAXMRTwTJ&quot;</td><td>&quot;&quot;</td><td>0</td></tr><tr><td>&quot;sz_2&quot;</td><td>&quot;NK-3p3mmVWmjwVtTfKchz4kNE&quot;</td><td>&quot;&quot;</td><td>0</td></tr><tr><td>&quot;sz_3&quot;</td><td>&quot;NK-auyPsLrBzRoxjCRWgjBvas&quot;</td><td>&quot;&quot;</td><td>0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 4)\n",
+       "┌────────┬───────────────────────────┬─────┬───────┐\n",
+       "│ ent_id ┆ rec_id                    ┆ why ┆ level │\n",
+       "│ ---    ┆ ---                       ┆ --- ┆ ---   │\n",
+       "│ str    ┆ str                       ┆ str ┆ i64   │\n",
+       "╞════════╪═══════════════════════════╪═════╪═══════╡\n",
+       "│ sz_1   ┆ NK-25vyVFzt8vdJGgAXMRTwTJ ┆     ┆ 0     │\n",
+       "│ sz_2   ┆ NK-3p3mmVWmjwVtTfKchz4kNE ┆     ┆ 0     │\n",
+       "│ sz_3   ┆ NK-auyPsLrBzRoxjCRWgjBvas ┆     ┆ 0     │\n",
+       "└────────┴───────────────────────────┴─────┴───────┘"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "df_sz_os = df_sz.filter(pl.col(\"source\") == \"OPEN-SANCTIONS\").select(\"ent_id\", \"rec_id\", \"why\", \"level\")\n",
-    "df_sz_oo = df_sz.filter(pl.col(\"source\") == \"OPEN-OWNERSHIP\").select(\"ent_id\", \"rec_id\", \"why\", \"level\")"
+    "df_sz_os = sz_export.df_rec.filter(pl.col(\"source\") == \"OPEN-SANCTIONS\").select(\"ent_id\", \"rec_id\", \"why\", \"level\")\n",
+    "df_sz_os.head(3)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Copy data to Kuzu graph\n",
-    "\n",
+    "## Copy data to Kuzu graph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Kuzu is an embedded, open source graph database that supports the Cypher query language. It uses a structured property graph model, which is similar to the labelled property graph model you may be familiar with from other systems -- the only difference being that Kuzu requires strict data types for properties in the schema.\n",
     "\n",
     "The following steps will create the graph schema in Kuzu (node and relationship tables) and copy the data into them."
@@ -627,7 +764,15 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.514208Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.514124Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.516459Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.516154Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.514202Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create a yFiles graph widget so we can explore our graph as it's created\n",
@@ -637,12 +782,20 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.517007Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.516832Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.524359Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.524149Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.516997Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<kuzu.query_result.QueryResult at 0x10b46cfc0>"
+       "<kuzu.query_result.QueryResult at 0x1155803e0>"
       ]
      },
      "execution_count": 17,
@@ -661,12 +814,20 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.524845Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.524726Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.631942Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.631658Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.524837Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<kuzu.query_result.QueryResult at 0x10ee17050>"
+       "<kuzu.query_result.QueryResult at 0x115371b50>"
       ]
      },
      "execution_count": 18,
@@ -678,19 +839,27 @@
     "conn.execute(\"COPY OpenSanctions FROM df_os\")\n",
     "conn.execute(\"COPY OpenOwnership FROM df_oo\")\n",
     "conn.execute(\"COPY Risk FROM (LOAD FROM df_risk RETURN DISTINCT topic)\")\n",
-    "conn.execute(\"COPY Entity FROM (LOAD FROM df_ent RETURN ent_id AS id, descrip)\")\n",
-    "conn.execute(\"COPY Role FROM df_oa_relationships\")\n"
+    "conn.execute(\"COPY Entity FROM (LOAD FROM df_ent RETURN id, descrip)\")\n",
+    "conn.execute(\"COPY Role FROM df_oa_relationships\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.632352Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.632250Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.656840Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.656570Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.632344Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "384befcfb0e5487984c681da52674f51",
+       "model_id": "cc058e0cab294692be37dcdea465e2cf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -709,7 +878,15 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.657310Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.657244Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.673177Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.672878Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.657303Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create Related table between entities\n",
@@ -720,12 +897,20 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.675615Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.675500Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.689542Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.689209Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.675606Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f1a8948c649e45258dafb8aeed1df355",
+       "model_id": "bef1b0ee0b70499eaee8b6d2750f2466",
        "version_major": 2,
        "version_minor": 0
       },
@@ -748,9 +933,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll need to create `Matched` relationships between the entities in our graph. The from/to columns in the following table are the source and destination Senzing identifiers."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.690091Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.690018Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.718579Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.718273Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.690084Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create Matched table between multiple sets of entities\n",
@@ -771,12 +971,20 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.719067Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.718982Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.734537Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.734284Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.719056Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<kuzu.query_result.QueryResult at 0x129dab2f0>"
+       "<kuzu.query_result.QueryResult at 0x1253ab710>"
       ]
      },
      "execution_count": 23,
@@ -793,17 +1001,25 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-04-20T20:57:12.735069Z",
+     "iopub.status.busy": "2025-04-20T20:57:12.734944Z",
+     "iopub.status.idle": "2025-04-20T20:57:12.749688Z",
+     "shell.execute_reply": "2025-04-20T20:57:12.749466Z",
+     "shell.execute_reply.started": "2025-04-20T20:57:12.735060Z"
+    }
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "800e18ebcbcb408491d8c5f4e807a8cc",
+       "model_id": "3af38d38d66b45f786bb5af0ba0f66e8",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "GraphWidget(layout=Layout(height='630px', width='100%'))"
+       "GraphWidget(layout=Layout(height='500px', width='100%'))"
       ]
      },
      "metadata": {},
@@ -831,7 +1047,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -849,5 +1065,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/process_senzing.py
+++ b/process_senzing.py
@@ -1,60 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from dataclasses import dataclass
+import json
+import pathlib
+import typing
+
+from icecream import ic
 import polars as pl
 
-# --- Senzing Export ---
 
-def process_senzing_export(df: pl.DataFrame) -> pl.DataFrame:
-    # Extract RECORDS field from RESOLVED_ENTITY struct and then explode
-    df = df.with_columns([
-        pl.col("RESOLVED_ENTITY").struct.field("RECORDS").alias("RECORDS")
-    ])
-    df = df.explode("RECORDS")
-    
-    # Extract fields from the RECORDS struct
-    df = df.with_columns([
-        (pl.lit("sz_") + pl.col("RESOLVED_ENTITY").struct.field("ENTITY_ID").cast(pl.Utf8)).alias("ent_id"),
-        pl.col("RECORDS").struct.field("RECORD_ID").alias("rec_id"),
-        pl.col("RECORDS").struct.field("DATA_SOURCE").alias("source"),
-        pl.col("RECORDS").struct.field("ENTITY_DESC").alias("descrip"),
-        pl.col("RECORDS").struct.field("MATCH_LEVEL").cast(pl.Int8).alias("level"),
-        pl.col("RECORDS").struct.field("MATCH_KEY").replace("", None).alias("why"),
-    ]).drop_nulls(subset=["descrip"])
-    
-    return df.select(
-        pl.col("ent_id"),
-        pl.col("rec_id"),
-        pl.col("source"),
-        pl.col("descrip"),
-        pl.col("level"),
-        pl.col("why"),
+@dataclass(order = False, frozen = False)
+class SzExport:  # pylint: disable=R0902
+    "A data class for graph elements parsed from a Senzing export."
+    df_ent: pl.DataFrame
+    df_rec: pl.DataFrame
+    df_rel: pl.DataFrame
+
+
+def process_senzing_export (
+    sz_export_file: pathlib.Path,
+    ) -> SzExport:
+    "Parse graph elements from the Senzing export JSON file."
+    er_entity_prefix: str = "sz_"
+    ent_rows: typing.List[ dict ] = []
+    rec_rows: typing.List[ dict ] = []
+    rel_rows: typing.List[ dict ] = []
+
+    with open(sz_export_file, "rb") as fp:
+        for line in fp:
+            dat: dict = json.loads(line)
+            ent_id: str = er_entity_prefix + str(dat["RESOLVED_ENTITY"]["ENTITY_ID"]).strip()
+            ent_desc: typing.Optional[ str ] = None
+
+            # link to resolved data records
+            for dat_rec in dat["RESOLVED_ENTITY"]["RECORDS"]:
+                rec_id = dat_rec["RECORD_ID"]
+
+                rec_rows.append({
+                    "ent_id": ent_id,
+                    "rec_id": rec_id,
+                    "source": dat_rec["DATA_SOURCE"],
+                    "why": dat_rec["MATCH_KEY"],
+                    "level": dat_rec["MATCH_LEVEL"],
+                })
+
+                desc: str = dat_rec["ENTITY_DESC"].strip()
+
+                if len(desc) > 0:
+                    ent_desc = desc
+
+            ent_rows.append({
+                "id": ent_id,
+                "descrip": ent_desc,
+            })
+
+            # link to related entities
+            for rel_rec in dat["RELATED_ENTITIES"]:
+                rel_id: str = er_entity_prefix + str(rel_rec["ENTITY_ID"]).strip()
+
+                rel_rows.append({
+                    "ent_id": ent_id,
+                    "rel_id": rel_id,
+                    "why": rel_rec["MATCH_KEY"],
+                    "level": rel_rec["MATCH_LEVEL"],
+                })
+
+    return  SzExport(
+        pl.DataFrame(ent_rows),
+        pl.DataFrame(rec_rows),
+        pl.DataFrame(rel_rows),
     )
 
 
-def extract_related_entities(df: pl.DataFrame) -> pl.DataFrame:
-    df = df.explode("RELATED_ENTITIES")
-
-    df = df.with_columns([
-        (pl.lit("sz_") + pl.col("RESOLVED_ENTITY").struct.field("ENTITY_ID").cast(pl.Utf8)).alias("ent_id"),
-        (pl.lit("sz_") + pl.col("RELATED_ENTITIES").struct.field("ENTITY_ID").cast(pl.Utf8)).alias("rel_id"),
-        pl.col("RELATED_ENTITIES").struct.field("MATCH_KEY").alias("why"),
-        pl.col("RELATED_ENTITIES").struct.field("MATCH_LEVEL").cast(pl.Int8).alias("level"),
-    ])
-
-    return df.select(
-        pl.col("ent_id"),
-        pl.col("rel_id"),
-        pl.col("why"),
-        pl.col("level"),
-    ).drop_nulls(subset=["ent_id", "rel_id"])
-
-
 if __name__ == "__main__":
-    # Read as JSONL instead of JSON
-    df = pl.read_ndjson("data/export.json")
-    df_sz = process_senzing_export(df)
-    df_rel = extract_related_entities(df)
-    df_rel.count()
-    df_ent = df_sz.unique(subset=["ent_id"]).select("ent_id", "descrip").sort("ent_id")
+    sz_export_file: pathlib.Path = pathlib.Path("data") / "export.json"
+    sz_export = process_senzing_export(sz_export_file)
 
-    df_sz_os = df_sz.filter(pl.col("source") == "OPEN-SANCTIONS")
-    df_sz_oa = df_sz.filter(pl.col("source") == "OPEN-OWNERSHIP")
-    
+    ic(sz_export.df_ent.head())
+    ic(sz_export.df_rec.head())
+    ic(sz_export.df_rel.head())


### PR DESCRIPTION
@prrao87 here are the updates for:

  * Describing more context about the OpenSanctions and Open Ownership data sources.
  * Integrating the Senzing workflow.

For the latter, the nesting within the Senzing `export.json` file is too deep to use Polars to load the JSON first. Instead, I'm reading it as a JSONL file, then parsing each entity's JSON doc to extract three "list of dict" data structures: `ent_rows`, `rec_rows`, `rel_rows` -- and from this it's simple to build Polars dataframes.

I believe these changes didn't corrupt any of the data, and the results appear to be the same. Can we use this?